### PR TITLE
Get a teapot without cloning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,11 +19,8 @@ $ curl -X BREW -i https://teapot.now.sh
 ## Get your own teapot server
 
 ```sh
-# Download the code
-git clone git@github.com:mxstbr/teapot.git
-
 # Deploy your own version (requires https://now.sh)
-now
+now mxstbr/teapot
 ```
 
 ## License


### PR DESCRIPTION
You can deploy GitHub repos to Now without cloning them: https://zeit.co/docs/features/repositories